### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Redis/RedisScaleoutOptions.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/RedisScaleoutOptions.cs
@@ -23,12 +23,12 @@ namespace Microsoft.AspNet.SignalR.Redis
         {
             if (String.IsNullOrEmpty(connectionString))
             {
-                throw new ArgumentNullException("connectionString");
+                throw new ArgumentNullException(nameof(connectionString));
             }
 
             if (String.IsNullOrEmpty(eventKey))
             {
-                throw new ArgumentNullException("eventKey");
+                throw new ArgumentNullException(nameof(eventKey));
             }
 
             ConnectionString = connectionString;


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason
